### PR TITLE
Fix annotation pass shallowness

### DIFF
--- a/src/core/compiler/passes/annotation.ts
+++ b/src/core/compiler/passes/annotation.ts
@@ -1,7 +1,44 @@
 import {SelectiveIrVisitor} from '../ir'
-import {CommandCompositeNode, DatapackNode, FunctionDefinitionNode, OnLoadNode, OnTickNode, ProcedureParameterNode} from '../ir'
+import {
+  CommandCompositeNode,
+  DatapackNode,
+  FunctionDefinitionNode,
+  ProcedureParameterNode,
+  FragmentCompositeNode,
+  TargetSelectorNode,
+  LiteralPositionNode,
+  LiteralRangeNode,
+  LiteralRotationNode,
+  LiteralIntNode,
+  LiteralStringNode,
+  VariableNode,
+  FunctionCallNode,
+  TempVariableNode,
+  ItemStackNode,
+} from '../ir'
 
+/**
+ * The `AnnotationPass` traverses the IR deeply. If any descendant of a
+ * `CommandCompositeNode` contains a `ProcedureParameterNode`, that `CommandCompositeNode`
+ * must be marked as a macro (`isMacro = true`). We track the current enclosing
+ * `CommandCompositeNode` with a stack while traversing nested fragments.
+ */
 export class AnnotationPass extends SelectiveIrVisitor<void> {
+  private commandStack: CommandCompositeNode[] = []
+
+  private pushCommand(node: CommandCompositeNode) {
+    this.commandStack.push(node)
+  }
+
+  private popCommand(): void {
+    this.commandStack.pop()
+  }
+
+  private markCurrentAsMacro(): void {
+    const current = this.commandStack[this.commandStack.length - 1]
+    if (current) current.isMacro = true
+  }
+
   visitDatapack(node: DatapackNode): void {
     node.topLevelNodes.forEach(n => n.accept(this))
   }
@@ -10,18 +47,59 @@ export class AnnotationPass extends SelectiveIrVisitor<void> {
     node.bodyNodes.forEach(n => n.accept(this))
   }
 
-  visitOnLoad(node: OnLoadNode): void {
-    node.bodyNodes.forEach(n => n.accept(this))
-  }
-
-  visitOnTick(node: OnTickNode): void {
-    node.bodyNodes.forEach(n => n.accept(this))
-  }
-
   visitCommandComposite(node: CommandCompositeNode): void {
-    const hasProcedureParameter = node.parts.some(part => part instanceof ProcedureParameterNode)
-    if (hasProcedureParameter) {
-      node.isMacro = true
-    }
+    this.pushCommand(node)
+    // parts can be FragmentNode or string
+    node.parts.forEach(part => {
+      if (typeof part !== 'string') part.accept(this)
+    })
+    this.popCommand()
   }
+
+  visitFragmentComposite(node: FragmentCompositeNode): void {
+    node.parts.forEach(part => {
+      if (typeof part !== 'string') part.accept(this)
+    })
+  }
+  visitTargetSelector(node: TargetSelectorNode): void {
+    node.clauseNodes.forEach(c => c.accept(this))
+  }
+
+  visitLiteralPosition(node: LiteralPositionNode): void {
+    node.xNode.accept(this)
+    node.yNode.accept(this)
+    node.zNode.accept(this)
+  }
+
+  visitLiteralRange(node: LiteralRangeNode): void {
+    node.minNode.accept(this)
+    node.maxNode.accept(this)
+  }
+
+  visitLiteralRotation(node: LiteralRotationNode): void {
+    node.yawNode.accept(this)
+    node.pitchNode.accept(this)
+  }
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+
+  visitLiteralInt(_node: LiteralIntNode): void {}
+
+  visitLiteralString(_node: LiteralStringNode): void {}
+
+  visitVariable(_node: VariableNode): void {}
+
+  visitFunctionCall(_node: FunctionCallNode): void {}
+
+  visitTempVariable(_node: TempVariableNode): void {}
+
+  visitItemStack(_node: ItemStackNode): void {}
+
+  visitProcedureParameter(_node: ProcedureParameterNode): void {
+    // When a procedure parameter is encountered anywhere under a CommandNode,
+    // mark the nearest enclosing CommandNode as a macro.
+    this.markCurrentAsMacro()
+  }
+
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 }


### PR DESCRIPTION
Now deeply traverse the IR in AnnotationPass instead of shallow `isinstance` checks before.