### PR TITLE
confirm-dialogue

### DIFF
--- a/src/ui/editor/modal/EditorModal.tsx
+++ b/src/ui/editor/modal/EditorModal.tsx
@@ -48,20 +48,20 @@ export function EditorModal() {
           overflow: 'hidden'
         }),
       }}>
-        <Stack direction={'row'} sx={{
-          flex: '0 0 auto',
-          backgroundColor: 'background.paper',
-          alignItems: 'center',
-          p: 1,
-          pl: 2,
-          borderTopLeftRadius: theme => theme.shape.surfaceBorderRadius,
-          borderTopRightRadius: theme => theme.shape.surfaceBorderRadius
-        }}>
-          <Typography variant={'h6'} sx={{
-            flex: 1,
-          }}>{payload.title}</Typography>
-          <MaximizeButton maximized={maximized}/>
-        </Stack>
+         <Stack direction={'row'} sx={{
+           flex: '0 0 auto',
+           backgroundColor: 'background.paper',
+           alignItems: 'center',
+           p: 1,
+           pl: 2,
+           borderTopLeftRadius: theme => theme.shape.surfaceBorderRadius,
+           borderTopRightRadius: theme => theme.shape.surfaceBorderRadius
+         }}>
+           <Typography variant={'h6'} sx={{
+             flex: 1,
+           }}>{payload.title}</Typography>
+           {!payload.noFullscreen && <MaximizeButton maximized={maximized}/>}
+         </Stack>
         <Box sx={{
           backgroundColor: 'background.paper',
           p: 1,

--- a/src/ui/editor/modal/controller.ts
+++ b/src/ui/editor/modal/controller.ts
@@ -6,6 +6,7 @@ type Listener = () => void
 type EditorModalPayloadBase = {
   title: string
   editor: React.ReactNode
+  noFullscreen?: boolean
 }
 
 type EditorModalPayload =

--- a/src/ui/ide/MenuBar/index.tsx
+++ b/src/ui/ide/MenuBar/index.tsx
@@ -5,7 +5,7 @@ import {ProjectNameDisplay} from "./ProjectNameDisplay.tsx";
 import {useIDEContext} from "../context/useIDEContext.ts";
 import {ActionButtons} from "./ActionButtons.tsx";
 import {controller} from '../../editor'
-import {Confirmation} from '../WorkspaceDialogues'
+import {TextDialogue} from '../WorkspaceDialogues'
 
 export function MenuBar() {
   const {blocklyWorkspaceRef, setHasUnsavedFileChanges} = useIDEContext()
@@ -47,10 +47,10 @@ export function MenuBar() {
                 controller.openEditorModal({
                   title: 'Unsaved changes',
                   editor: (
-                    <Confirmation>
+                    <TextDialogue>
                       Unsaved changes will be lost when another project is opened. Proceed?<br/>
                       Save changes to your computer with <b>File {'>'} Save</b>.
-                    </Confirmation>
+                    </TextDialogue>
                   ),
                   mode: 'confirm',
                   onConfirm: () => {
@@ -68,10 +68,10 @@ export function MenuBar() {
                 controller.openEditorModal({
                   title: 'Unsaved changes',
                   editor: (
-                    <Confirmation>
+                    <TextDialogue>
                       Unsaved changes will be lost when a new project is created. Proceed?<br/>
                       Save changes to your computer with <b>File {'>'} Save</b>.
-                    </Confirmation>
+                    </TextDialogue>
                   ),
                   mode: 'confirm',
                   onConfirm: () => {

--- a/src/ui/ide/MenuBar/index.tsx
+++ b/src/ui/ide/MenuBar/index.tsx
@@ -57,7 +57,8 @@ export function MenuBar() {
                     if (!blocklyWorkspaceRef.current) return
                     loadProject({workspace: blocklyWorkspaceRef.current})
                     setHasUnsavedFileChanges(false)
-                  }
+                  },
+                  noFullscreen: true
                 })
               }
             },
@@ -77,7 +78,8 @@ export function MenuBar() {
                     if (!blocklyWorkspaceRef.current) return
                     newProject(blocklyWorkspaceRef.current)
                     setHasUnsavedFileChanges(true) // A new project is not yet saved to computer.
-                  }
+                  },
+                  noFullscreen: true
                 })
               }
             }

--- a/src/ui/ide/MenuBar/index.tsx
+++ b/src/ui/ide/MenuBar/index.tsx
@@ -4,6 +4,8 @@ import {loadProject, newProject, saveProject} from "../../../core/save";
 import {ProjectNameDisplay} from "./ProjectNameDisplay.tsx";
 import {useIDEContext} from "../context/useIDEContext.ts";
 import {ActionButtons} from "./ActionButtons.tsx";
+import {controller} from '../../editor'
+import {Confirmation} from '../WorkspaceDialogues'
 
 export function MenuBar() {
   const {blocklyWorkspaceRef, setHasUnsavedFileChanges} = useIDEContext()
@@ -42,23 +44,41 @@ export function MenuBar() {
             {
               text: 'Open',
               onClick: () => {
-                if (!blocklyWorkspaceRef.current) return
-                // TODO proper dialogue
-                if (confirm('Unsaved changes will be lost when another project is opened. Proceed?')) {
-                  loadProject({workspace: blocklyWorkspaceRef.current})
-                  setHasUnsavedFileChanges(false)
-                }
+                controller.openEditorModal({
+                  title: 'Unsaved changes',
+                  editor: (
+                    <Confirmation>
+                      Unsaved changes will be lost when another project is opened. Proceed?<br/>
+                      Save changes to your computer with <b>File {'>'} Save</b>.
+                    </Confirmation>
+                  ),
+                  mode: 'confirm',
+                  onConfirm: () => {
+                    if (!blocklyWorkspaceRef.current) return
+                    loadProject({workspace: blocklyWorkspaceRef.current})
+                    setHasUnsavedFileChanges(false)
+                  }
+                })
               }
             },
             {
               text: 'New',
               onClick: () => {
-                if (!blocklyWorkspaceRef.current) return
-                // TODO proper dialogue
-                if (confirm('Unsaved changes will be lost when another project is created. Proceed?')) {
-                  newProject(blocklyWorkspaceRef.current)
-                  setHasUnsavedFileChanges(true) // A new project is not yet saved to computer.
-                }
+                controller.openEditorModal({
+                  title: 'Unsaved changes',
+                  editor: (
+                    <Confirmation>
+                      Unsaved changes will be lost when a new project is created. Proceed?<br/>
+                      Save changes to your computer with <b>File {'>'} Save</b>.
+                    </Confirmation>
+                  ),
+                  mode: 'confirm',
+                  onConfirm: () => {
+                    if (!blocklyWorkspaceRef.current) return
+                    newProject(blocklyWorkspaceRef.current)
+                    setHasUnsavedFileChanges(true) // A new project is not yet saved to computer.
+                  }
+                })
               }
             }
           ]}/>

--- a/src/ui/ide/WorkspaceDialogues/Confirmation.tsx
+++ b/src/ui/ide/WorkspaceDialogues/Confirmation.tsx
@@ -1,0 +1,14 @@
+import {Box, Typography} from '@mui/material'
+import * as React from 'react'
+
+export function Confirmation({ children }: { children: React.ReactNode }) {
+  return (
+    <Box sx={{
+      width: '40rem',
+      height: 'auto',
+      p: 1,
+    }}>
+      <Typography>{children}</Typography>
+    </Box>
+  )
+}

--- a/src/ui/ide/WorkspaceDialogues/TextDialogue.tsx
+++ b/src/ui/ide/WorkspaceDialogues/TextDialogue.tsx
@@ -1,7 +1,7 @@
 import {Box, Typography} from '@mui/material'
 import * as React from 'react'
 
-export function Confirmation({ children }: { children: React.ReactNode }) {
+export function TextDialogue({ children }: { children: React.ReactNode }) {
   return (
     <Box sx={{
       width: '40rem',

--- a/src/ui/ide/WorkspaceDialogues/index.ts
+++ b/src/ui/ide/WorkspaceDialogues/index.ts
@@ -1,3 +1,3 @@
 export {CreateProcedure} from './CreateProcedure.tsx'
 export {CreateVariable} from './CreateVariable.tsx'
-export {Confirmation} from './Confirmation.tsx'
+export {TextDialogue} from './TextDialogue.tsx'

--- a/src/ui/ide/WorkspaceDialogues/index.ts
+++ b/src/ui/ide/WorkspaceDialogues/index.ts
@@ -1,2 +1,3 @@
 export {CreateProcedure} from './CreateProcedure.tsx'
 export {CreateVariable} from './CreateVariable.tsx'
+export {Confirmation} from './Confirmation.tsx'


### PR DESCRIPTION
Added a confirmation dialogue for creating new project and opening another project. Added a new IDE dialogue component, TextDialogue, for simple text-based dialogues like these, to be opened via the Editor modal controller.