### PR TITLE
block-mined-event

### DIFF
--- a/src/core/blockly/specs/categories/events.ts
+++ b/src/core/blockly/specs/categories/events.ts
@@ -1,5 +1,14 @@
 import type { BlockSpec } from '../types'
-import {CommandNode, OnLoadNode, OnTickNode, nextBlocksToIr} from '../../../compiler'
+import {
+  CommandNode,
+  OnLoadNode,
+  OnTickNode,
+  nextBlocksToIr,
+  OnPlayerMinesBlockNode,
+  valueToIr,
+  LiteralStringNode
+} from '../../../compiler'
+import {setShadowState} from '../../extensions/shadows.ts'
 
 export const eventBlockSpecs: BlockSpec[] = [
   {
@@ -34,4 +43,31 @@ export const eventBlockSpecs: BlockSpec[] = [
       )
     }
   },
+  {
+    type: 'mc_on_player_mined_block',
+    category: 'events',
+    json: {
+      type: 'mc_on_player_mined_block',
+      message0: 'when a player mines %1',
+      args0: [
+        {
+          type: 'input_value',
+          name: 'BLOCK',
+          check: ['mc_string'],
+        },
+      ],
+      inputsInline: true,
+      nextStatement: null
+    },
+    generator(block) {
+      return new OnPlayerMinesBlockNode(
+        valueToIr(block, 'BLOCK') as LiteralStringNode,
+        nextBlocksToIr(block) as CommandNode[],
+        block.id
+      )
+    },
+    setShadowBlocks(this) {
+      setShadowState(this, 'BLOCK', { type: 'mc_string', fields: { VALUE: 'stone' } })
+    }
+  }
 ]

--- a/src/core/compiler/emitter/emitter.ts
+++ b/src/core/compiler/emitter/emitter.ts
@@ -113,14 +113,14 @@ export class Emitter extends SelectiveIrVisitor<Segment[]> {
     if (this.loadFunctionNames.length) {
       this.files.with('data/minecraft/tags/function/load.json').write([new Segment(
         JSON.stringify({
-          value: Array.from(new Set(this.loadFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
+          values: Array.from(new Set(this.loadFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
         }, null, 2)
       )])
     }
     if (this.tickFunctionNames.length) {
       this.files.with('data/minecraft/tags/function/tick.json').write([new Segment(
         JSON.stringify({
-          value: Array.from(new Set(this.tickFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
+          values: Array.from(new Set(this.tickFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
         }, null, 2)
       )])
     }

--- a/src/core/compiler/emitter/emitter.ts
+++ b/src/core/compiler/emitter/emitter.ts
@@ -2,7 +2,7 @@ import {
   DatapackNode, ItemStackNode, LiteralRotationNode, LiteralIntNode,
   LiteralPositionNode, LiteralRangeNode, LiteralStringNode,
   ProcedureParameterNode, TargetSelectorNode, VariableNode, CommandCompositeNode,
-  FragmentCompositeNode, TempVariableNode, FunctionDefinitionNode, FunctionCallNode
+  FragmentCompositeNode, TempVariableNode, FunctionDefinitionNode, FunctionCallNode, FunctionTagNode
 } from '../ir'
 import {OutputFiles} from '../outputFiles.ts'
 import {Naming} from './naming.ts'
@@ -18,6 +18,10 @@ export class Emitter extends SelectiveIrVisitor<Segment[]> {
   readonly projectConfig: ProjectConfig
 
   private parentProcedure: ProcedureRegistryEntry | null = null
+
+  // Populated as the pass encounters `FunctionTagNode`s
+  private loadFunctionNames: string[] = []
+  private tickFunctionNames: string[] = []
 
   constructor(outputFiles: OutputFiles, projectConfig: ProjectConfig) {
     super()
@@ -95,38 +99,38 @@ export class Emitter extends SelectiveIrVisitor<Segment[]> {
     // Should prevent this in the future.
     node.topLevelNodes.forEach(n => n.accept(this))
 
-    if (this.files.exists(this.naming.internalMcfunctionFilePath('tick'))) {
-      // By default, minecraft's execution order is "tick -> load -> tick -> tick -> ..."
-      // This checks an INIT flag to get rid of this behaviour.
-      this.files.with(this.naming.internalMcfunctionFilePath('load')).prepend([new Segment(
-        `scoreboard players set ${this.naming.initializedFlagName()} ${this.naming.variableObjectiveName()} 1\n`
-      )])
-      this.files.with(this.naming.internalMcfunctionFilePath('tick')).prepend([new Segment(
-        `execute unless score ${this.naming.initializedFlagName()} ${this.naming.variableObjectiveName()} matches 1 run return fail\n`
-      )])
-
-      // Only register tick tag if tick.mcfunction exists
-      this.files.with('data/minecraft/tags/function/tick.json').write([new Segment(
-        JSON.stringify({
-          value: [`${this.naming.internalNamespace()}:tick`]
-        }, null, 2)
-      )])
-    }
-
     // Always initialize a dummy variable objective unless there are no top-level nodes.
     // Could set a flag when variables are used but probably not worth it.
     if (node.topLevelNodes.length) {
       this.files.with(this.naming.internalMcfunctionFilePath('load')).prepend([new Segment(
         `scoreboard objectives add ${this.naming.variableObjectiveName()} dummy\n`
       )])
-
       // Always register load tag due to needing to initialize the dummy objective.
+      this.loadFunctionNames.push('load')
+    }
+
+    // Populate function tags
+    if (this.loadFunctionNames.length) {
       this.files.with('data/minecraft/tags/function/load.json').write([new Segment(
         JSON.stringify({
-          value: [`${this.naming.internalNamespace()}:load`]
+          value: Array.from(new Set(this.loadFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
         }, null, 2)
       )])
     }
+    if (this.tickFunctionNames.length) {
+      this.files.with('data/minecraft/tags/function/tick.json').write([new Segment(
+        JSON.stringify({
+          value: Array.from(new Set(this.tickFunctionNames)).map(name => `${this.naming.internalNamespace()}:${name}`)
+        }, null, 2)
+      )])
+    }
+
+    return []
+  }
+
+  visitFunctionTag(node: FunctionTagNode): Segment[] {
+    if (node.tag === 'tick') this.tickFunctionNames.push(node.name)
+    else this.loadFunctionNames.push(node.name)
 
     return []
   }

--- a/src/core/compiler/emitter/emitter.ts
+++ b/src/core/compiler/emitter/emitter.ts
@@ -29,7 +29,7 @@ export class Emitter extends SelectiveIrVisitor<Segment[]> {
   visitCommandComposite(node: CommandCompositeNode): Segment[] {
     const res: Segment[] = []
     for (let i = 0; i < node.parts.length; i++) {
-      if (i > 0) res.push(new Segment(' ', node))
+      if (i > 0 && !node.noSpace) res.push(new Segment(' ', node))
       const part = node.parts[i]
       if (typeof part === 'string') {
         res.push(new Segment(part, node))
@@ -44,7 +44,7 @@ export class Emitter extends SelectiveIrVisitor<Segment[]> {
   visitFragmentComposite(node: FragmentCompositeNode): Segment[] {
     const res: Segment[] = []
     for (let i = 0; i < node.parts.length; i++) {
-      if (i > 0) res.push(new Segment(' ', node))
+      if (i > 0 && !node.noSpace) res.push(new Segment(' ', node))
       const part = node.parts[i]
       if (typeof part === 'string') {
         res.push(new Segment(part, node))

--- a/src/core/compiler/ir/nodes.ts
+++ b/src/core/compiler/ir/nodes.ts
@@ -53,10 +53,12 @@ export class DatapackNode extends IrNode {
 
 export class CommandCompositeNode extends CommandNode {
   readonly parts: (FragmentNode | string)[]
+  readonly noSpace: boolean
 
-  constructor(parts: (FragmentNode | string)[], sourceBlockId?: string | null) {
+  constructor(parts: (FragmentNode | string)[], sourceBlockId?: string | null, noSpace?: boolean) {
     super(sourceBlockId)
     this.parts = parts
+    this.noSpace = noSpace ?? false
   }
 
   accept<T>(visitor: IrVisitor<T>): T {
@@ -66,10 +68,12 @@ export class CommandCompositeNode extends CommandNode {
 
 export class FragmentCompositeNode extends FragmentNode {
   readonly parts: (FragmentNode | string)[]
+  readonly noSpace: boolean
 
-  constructor(parts: (FragmentNode | string)[], sourceBlockId?: string | null) {
+  constructor(parts: (FragmentNode | string)[], sourceBlockId?: string | null, noSpace?: boolean) {
     super(sourceBlockId)
     this.parts = parts
+    this.noSpace = noSpace ?? false
   }
 
   accept<T>(visitor: IrVisitor<T>): T {
@@ -131,6 +135,21 @@ export class OnTickNode extends IrNode {
 
   accept<T>(visitor: IrVisitor<T>): T {
     return visitor.visitOnTick(this)
+  }
+}
+
+export class OnPlayerMinesBlockNode extends IrNode {
+  readonly blockPredicate: LiteralStringNode
+  readonly bodyNodes: CommandNode[]
+
+  constructor(blockPredicate: LiteralStringNode, bodyNodes: CommandNode[], sourceBlockId?: string | null) {
+    super(sourceBlockId)
+    this.blockPredicate = blockPredicate
+    this.bodyNodes = bodyNodes
+  }
+
+  accept<T>(visitor: IrVisitor<T>): T {
+    return visitor.visitOnPlayerMinesBlock(this)
   }
 }
 

--- a/src/core/compiler/ir/nodes.ts
+++ b/src/core/compiler/ir/nodes.ts
@@ -51,6 +51,21 @@ export class DatapackNode extends IrNode {
   }
 }
 
+export class FunctionTagNode extends IrNode {
+  readonly tag: 'load' | 'tick'
+  readonly name: string
+
+  constructor(tag: "load" | "tick", name: string, sourceBlockId?: string | null) {
+    super(sourceBlockId)
+    this.tag = tag
+    this.name = name
+  }
+
+  accept<T>(visitor: IrVisitor<T>): T {
+    return visitor.visitFunctionTag(this)
+  }
+}
+
 export class CommandCompositeNode extends CommandNode {
   readonly parts: (FragmentNode | string)[]
   readonly noSpace: boolean

--- a/src/core/compiler/ir/visitor.ts
+++ b/src/core/compiler/ir/visitor.ts
@@ -6,7 +6,8 @@ import {
   VariableNode,
   VariableOperationNode, ExecuteNode, LiteralPositionNode, LiteralRangeNode, LiteralRotationNode, TargetSelectorNode,
   VariableMatchesNode, VariableCompareNode, IfNode, WhileNode, CommandCompositeNode, FragmentCompositeNode,
-  TempVariableNode, VariableSetNode, FunctionDefinitionNode, FunctionCallNode, IrNode, OnPlayerMinesBlockNode
+  TempVariableNode, VariableSetNode, FunctionDefinitionNode, FunctionCallNode, IrNode, OnPlayerMinesBlockNode,
+  FunctionTagNode
 } from "./nodes.ts";
 
 export interface IrVisitor<T> {
@@ -16,6 +17,7 @@ export interface IrVisitor<T> {
   visitFunctionCall(node: FunctionCallNode): T
 
   visitDatapack(node: DatapackNode): T
+  visitFunctionTag(node: FunctionTagNode): T
 
   visitOnLoad(node: OnLoadNode): T
   visitOnTick(node: OnTickNode): T
@@ -162,6 +164,10 @@ export abstract class SelectiveIrVisitor<T> implements IrVisitor<T> {
   }
 
   visitOnPlayerMinesBlock(node: OnPlayerMinesBlockNode): T {
+    this.disallow(node)
+  }
+
+  visitFunctionTag(node: FunctionTagNode): T {
     this.disallow(node)
   }
 }

--- a/src/core/compiler/ir/visitor.ts
+++ b/src/core/compiler/ir/visitor.ts
@@ -6,7 +6,7 @@ import {
   VariableNode,
   VariableOperationNode, ExecuteNode, LiteralPositionNode, LiteralRangeNode, LiteralRotationNode, TargetSelectorNode,
   VariableMatchesNode, VariableCompareNode, IfNode, WhileNode, CommandCompositeNode, FragmentCompositeNode,
-  TempVariableNode, VariableSetNode, FunctionDefinitionNode, FunctionCallNode, IrNode
+  TempVariableNode, VariableSetNode, FunctionDefinitionNode, FunctionCallNode, IrNode, OnPlayerMinesBlockNode
 } from "./nodes.ts";
 
 export interface IrVisitor<T> {
@@ -19,6 +19,7 @@ export interface IrVisitor<T> {
 
   visitOnLoad(node: OnLoadNode): T
   visitOnTick(node: OnTickNode): T
+  visitOnPlayerMinesBlock(node: OnPlayerMinesBlockNode): T
 
   visitLiteralInt(node: LiteralIntNode): T
   visitLiteralString(node: LiteralStringNode): T
@@ -157,6 +158,10 @@ export abstract class SelectiveIrVisitor<T> implements IrVisitor<T> {
   }
 
   visitWhile(node: WhileNode): T {
+    this.disallow(node)
+  }
+
+  visitOnPlayerMinesBlock(node: OnPlayerMinesBlockNode): T {
     this.disallow(node)
   }
 }

--- a/src/core/compiler/passes/annotation.ts
+++ b/src/core/compiler/passes/annotation.ts
@@ -14,7 +14,7 @@ import {
   VariableNode,
   FunctionCallNode,
   TempVariableNode,
-  ItemStackNode,
+  ItemStackNode, FunctionTagNode,
 } from '../ir'
 
 /**
@@ -90,6 +90,8 @@ export class AnnotationPass extends SelectiveIrVisitor<void> {
   visitVariable(_node: VariableNode): void {}
 
   visitFunctionCall(_node: FunctionCallNode): void {}
+
+  visitFunctionTag(_node: FunctionTagNode): void {}
 
   visitTempVariable(_node: TempVariableNode): void {}
 

--- a/src/core/compiler/passes/lowering.ts
+++ b/src/core/compiler/passes/lowering.ts
@@ -6,7 +6,7 @@ import {
   IfNode,
   IrNode,
   type IrVisitor, ItemStackNode, LiteralIntNode, LiteralPositionNode, LiteralRangeNode, LiteralRotationNode,
-  LiteralStringNode, OnLoadNode, OnTickNode,
+  LiteralStringNode, OnLoadNode, OnPlayerMinesBlockNode, OnTickNode,
   type OrParameter, ProcedureCallArgumentNode, ProcedureCallNode, ProcedureDefinitionNode,
   ProcedureParameterNode, TargetSelectorNode, TempVariableNode,
   type TopLevelNode, VariableCompareNode, VariableMatchesNode, VariableNode,
@@ -268,6 +268,54 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
     return {
       pre: [],
       nodes: [new FunctionDefinitionNode('tick', this.lowerBody(node.bodyNodes), node.sourceBlockId)]
+    }
+  }
+
+  visitOnPlayerMinesBlock(node: OnPlayerMinesBlockNode): LoweredResult {
+    const baseName = this.naming.nextId('on_player_mines_block')
+
+    const minedObjName = `${baseName}_mined`
+    const prevObjName = `${baseName}_prev`
+
+    const loadFuncName = `${baseName}_load`
+    const bodyFuncName = `${baseName}_body`
+    const tickFuncName = `${baseName}_tick`
+    const checkFuncName = `${baseName}_check`
+
+    return {
+      pre: [],
+      nodes: [
+        // Initialize scoreboard objectives
+        new FunctionDefinitionNode(loadFuncName, [
+          new CommandCompositeNode([
+            `scoreboard objectives add ${minedObjName} minecraft.mined:minecraft.`, node.blockPredicate
+          ], node.sourceBlockId, true),
+          new CommandCompositeNode([
+            `scoreboard objectives add ${prevObjName} dummy`
+          ], node.sourceBlockId)
+        ], node.sourceBlockId),
+
+        // Define commands to run on block broken
+        new FunctionDefinitionNode(bodyFuncName, this.lowerBody(node.bodyNodes), node.sourceBlockId),
+
+        // Runs as a player; checks if the player mined a block. Calls body if yes
+        new FunctionDefinitionNode(checkFuncName, [
+          new CommandCompositeNode([
+            `execute if score @s ${minedObjName} > @s ${prevObjName} run`,
+            new FunctionCallNode(bodyFuncName, null, node.sourceBlockId)
+          ], node.sourceBlockId),
+          new CommandCompositeNode([
+            `scoreboard players operation @s ${prevObjName} = @s ${minedObjName}`
+          ], node.sourceBlockId)
+        ], node.sourceBlockId),
+
+        // Run check function every tick as each player
+        new FunctionDefinitionNode(tickFuncName, [
+          new CommandCompositeNode([
+            `execute as @s run`, new FunctionCallNode(checkFuncName, null, node.sourceBlockId)
+          ])
+        ])
+      ]
     }
   }
 

--- a/src/core/compiler/passes/lowering.ts
+++ b/src/core/compiler/passes/lowering.ts
@@ -325,7 +325,7 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
         // Run check function every tick as each player
         new FunctionDefinitionNode(tickFuncName, [
           new CommandCompositeNode([
-            `execute as @s run`, new FunctionCallNode(checkFuncName, null, node.sourceBlockId)
+            `execute as @a run`, new FunctionCallNode(checkFuncName, null, node.sourceBlockId)
           ])
         ]),
 

--- a/src/core/compiler/passes/lowering.ts
+++ b/src/core/compiler/passes/lowering.ts
@@ -288,12 +288,10 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
     const baseName = this.naming.nextId('on_player_mines_block')
 
     const minedObjName = `${baseName}_mined`
-    const prevObjName = `${baseName}_prev`
 
     const loadFuncName = `${baseName}_load`
     const bodyFuncName = `${baseName}_body`
     const tickFuncName = `${baseName}_tick`
-    const checkFuncName = `${baseName}_check`
 
     return {
       pre: [],
@@ -303,29 +301,19 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
           new CommandCompositeNode([
             `scoreboard objectives add ${minedObjName} minecraft.mined:minecraft.`, node.blockPredicate
           ], node.sourceBlockId, true),
-          new CommandCompositeNode([
-            `scoreboard objectives add ${prevObjName} dummy`
-          ], node.sourceBlockId)
         ], node.sourceBlockId),
 
         // Define commands to run on block broken
         new FunctionDefinitionNode(bodyFuncName, this.lowerBody(node.bodyNodes), node.sourceBlockId),
 
-        // Runs as a player; checks if the player mined a block. Calls body if yes
-        new FunctionDefinitionNode(checkFuncName, [
-          new CommandCompositeNode([
-            `execute if score @s ${minedObjName} > @s ${prevObjName} run`,
-            new FunctionCallNode(bodyFuncName, null, node.sourceBlockId)
-          ], node.sourceBlockId),
-          new CommandCompositeNode([
-            `scoreboard players operation @s ${prevObjName} = @s ${minedObjName}`
-          ], node.sourceBlockId)
-        ], node.sourceBlockId),
-
-        // Run check function every tick as each player
+        // A block was broken if objective isn't 0
         new FunctionDefinitionNode(tickFuncName, [
           new CommandCompositeNode([
-            `execute as @a run`, new FunctionCallNode(checkFuncName, null, node.sourceBlockId)
+            `execute as @a[scores={${minedObjName}=1..}] run`,
+            new FunctionCallNode(bodyFuncName, null, node.sourceBlockId)
+          ]),
+          new CommandCompositeNode([
+            `scoreboard players reset @a ${minedObjName}`
           ])
         ]),
 

--- a/src/core/compiler/passes/lowering.ts
+++ b/src/core/compiler/passes/lowering.ts
@@ -2,7 +2,7 @@ import {
   CommandCompositeNode, CommandNode,
   DatapackNode,
   ExecuteNode,
-  FragmentCompositeNode, FragmentNode, FunctionCallNode, FunctionDefinitionNode,
+  FragmentCompositeNode, FragmentNode, FunctionCallNode, FunctionDefinitionNode, FunctionTagNode,
   IfNode,
   IrNode,
   type IrVisitor, ItemStackNode, LiteralIntNode, LiteralPositionNode, LiteralRangeNode, LiteralRotationNode,
@@ -129,6 +129,13 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
     return {
       pre: [],
       nodes: [new DatapackNode(topLevelNodes)]
+    }
+  }
+
+  visitFunctionTag(node: FunctionTagNode): LoweredResult {
+    return {
+      pre: [],
+      nodes: [node]
     }
   }
 
@@ -260,14 +267,20 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
   visitOnLoad(node: OnLoadNode): LoweredResult {
     return {
       pre: [],
-      nodes: [new FunctionDefinitionNode('load', this.lowerBody(node.bodyNodes), node.sourceBlockId)]
+      nodes: [
+        new FunctionDefinitionNode('load', this.lowerBody(node.bodyNodes), node.sourceBlockId),
+        new FunctionTagNode('load', 'load', node.sourceBlockId)
+      ]
     }
   }
 
   visitOnTick(node: OnTickNode): LoweredResult {
     return {
       pre: [],
-      nodes: [new FunctionDefinitionNode('tick', this.lowerBody(node.bodyNodes), node.sourceBlockId)]
+      nodes: [
+        new FunctionDefinitionNode('tick', this.lowerBody(node.bodyNodes), node.sourceBlockId),
+        new FunctionTagNode('tick', 'tick', node.sourceBlockId)
+      ]
     }
   }
 
@@ -314,7 +327,11 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
           new CommandCompositeNode([
             `execute as @s run`, new FunctionCallNode(checkFuncName, null, node.sourceBlockId)
           ])
-        ])
+        ]),
+
+        // Register function tags
+        new FunctionTagNode('load', loadFuncName),
+        new FunctionTagNode('tick', tickFuncName),
       ]
     }
   }

--- a/src/core/compiler/passes/lowering.ts
+++ b/src/core/compiler/passes/lowering.ts
@@ -311,15 +311,15 @@ export class LoweringPass implements IrVisitor<LoweredResult> {
           new CommandCompositeNode([
             `execute as @a[scores={${minedObjName}=1..}] run`,
             new FunctionCallNode(bodyFuncName, null, node.sourceBlockId)
-          ]),
+          ], node.sourceBlockId),
           new CommandCompositeNode([
             `scoreboard players reset @a ${minedObjName}`
-          ])
-        ]),
+          ], node.sourceBlockId),
+        ], node.sourceBlockId),
 
         // Register function tags
-        new FunctionTagNode('load', loadFuncName),
-        new FunctionTagNode('tick', tickFuncName),
+        new FunctionTagNode('load', loadFuncName, node.sourceBlockId),
+        new FunctionTagNode('tick', tickFuncName, node.sourceBlockId),
       ]
     }
   }


### PR DESCRIPTION
Add "on player mines (block)" event. 

Body code runs `as` the player who broke the block, without specifying `at`.

Next steps include adding a way to detect the position of the broken block's position.